### PR TITLE
bugfix: error if labels are present

### DIFF
--- a/jenkins-backup.sh
+++ b/jenkins-backup.sh
@@ -58,7 +58,7 @@ function main() {
   fi
 
   rm -rf "${ARC_DIR}" "{$TMP_TAR_NAME}"
-  for plugin in plugins jobs users secrets nodes; do
+  for plugin in plugins jobs users secrets nodes labels; do
     mkdir -p "${ARC_DIR}/${plugin}"
   done
 


### PR DESCRIPTION
In the for-loop which creates the empty dirs in ARC_DIR, an entry for "labels" was missing.
This lead to an error if any labels were present.